### PR TITLE
Adds the necessary files to start building for the Internet Computer

### DIFF
--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/internetcomputer/TestInternetComputerAddress.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/internetcomputer/TestInternetComputerAddress.kt
@@ -1,0 +1,33 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+package com.trustwallet.core.app.blockchains.internetcomputer
+
+import com.trustwallet.core.app.utils.toHex
+import com.trustwallet.core.app.utils.toHexByteArray
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import wallet.core.jni.*
+
+class TestInternetComputerAddress {
+
+    init {
+        System.loadLibrary("TrustWalletCore")
+    }
+
+    @Test
+    fun testAddress() {
+        // TODO: Check and finalize implementation
+
+        val key = PrivateKey("__PRIVATE_KEY_DATA__".toHexByteArray())
+        val pubkey = key.publicKeyEd25519
+        val address = AnyAddress(pubkey, CoinType.INTERNETCOMPUTER)
+        val expected = AnyAddress("__EXPECTED_RESULT_ADDRESS__", CoinType.INTERNETCOMPUTER)
+
+        assertEquals(pubkey.data().toHex(), "0x__EXPECTED_PUBKEY_DATA__")
+        assertEquals(address.description(), expected.description())
+    }
+}

--- a/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/internetcomputer/TestInternetComputerSigner.kt
+++ b/android/app/src/androidTest/java/com/trustwallet/core/app/blockchains/internetcomputer/TestInternetComputerSigner.kt
@@ -1,0 +1,45 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+package com.trustwallet.core.app.blockchains.internetcomputer
+
+import com.google.protobuf.ByteString
+import com.trustwallet.core.app.utils.Numeric
+import com.trustwallet.core.app.utils.toHexByteArray
+import com.trustwallet.core.app.utils.toHexBytes
+import com.trustwallet.core.app.utils.toHexBytesInByteString
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import wallet.core.jni.InternetComputerSigner
+import wallet.core.jni.proto.InternetComputer
+
+class TestInternetComputerSigner {
+
+    init {
+        System.loadLibrary("TrustWalletCore")
+    }
+
+    @Test
+    fun InternetComputerTransactionSigning() {
+        // TODO: Finalize implementation
+
+        //val transfer = InternetComputer.TransferMessage.newBuilder()
+        //    .setTo("...")
+        //    .setAmount(...)
+        //    ...
+        //    .build()
+        //val signingInput = InternetComputer.SigningInput.newBuilder()
+        //    ...
+        //    .build()
+
+        //val output: InternetComputer.SigningOutput = InternetComputerSigner.sign(signingInput)
+
+        //assertEquals(
+        //    "__EXPECTED_RESULT_DATA__",
+        //    Numeric.toHexString(output.encoded.toByteArray())
+        //)
+    }
+}

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -35,6 +35,7 @@ This list is generated from [./registry.json](../registry.json)
 | 178     | POA Network      | POA    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/poa/info/logo.png" width="32" />          | <https://poa.network>         |
 | 194     | EOS              | EOS    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/eos/info/logo.png" width="32" />          | <http://eos.io>               |
 | 195     | Tron             | TRX    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/info/logo.png" width="32" />         | <https://tron.network>        |
+| 223     | Internet Computer | ICP    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/icp/info/logo.png" width="32" />          | <https://internetcomputer.org> |
 | 235     | FIO              | FIO    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/fio/info/logo.png" width="32" />          | <https://fioprotocol.io>      |
 | 242     | Nimiq            | NIM    | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/nimiq/info/logo.png" width="32" />        | <https://nimiq.com>           |
 | 283     | Algorand         | ALGO   | <img src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/algorand/info/logo.png" width="32" />     | <https://www.algorand.com/>   |

--- a/include/TrustWalletCore/TWBlockchain.h
+++ b/include/TrustWalletCore/TWBlockchain.h
@@ -47,22 +47,23 @@ enum TWBlockchain {
     TWBlockchainFilecoin = 32,
     TWBlockchainMultiversX = 33,
     TWBlockchainOasisNetwork = 34,
-    TWBlockchainDecred = 35, // Bitcoin
-    TWBlockchainZcash = 36, // Bitcoin
-    TWBlockchainGroestlcoin = 37, // Bitcoin
-    TWBlockchainThorchain = 38, // Cosmos
-    TWBlockchainRonin = 39, // Ethereum
-    TWBlockchainKusama = 40, // Polkadot
-    TWBlockchainZen = 41, // Bitcoin
+    TWBlockchainDecred = 35,         // Bitcoin
+    TWBlockchainZcash = 36,          // Bitcoin
+    TWBlockchainGroestlcoin = 37,    // Bitcoin
+    TWBlockchainThorchain = 38,      // Cosmos
+    TWBlockchainRonin = 39,          // Ethereum
+    TWBlockchainKusama = 40,         // Polkadot
+    TWBlockchainZen = 41,            // Bitcoin
     TWBlockchainBitcoinDiamond = 42, // Bitcoin
-    TWBlockchainVerge = 43, // Bitcoin
+    TWBlockchainVerge = 43,          // Bitcoin
     TWBlockchainNervos = 44,
     TWBlockchainEverscale = 45,
-    TWBlockchainAptos = 46, // Aptos
-    TWBlockchainNebl = 47, // Bitcoin
+    TWBlockchainAptos = 46,  // Aptos
+    TWBlockchainNebl = 47,   // Bitcoin
     TWBlockchainHedera = 48, // Hedera
     TWBlockchainTheOpenNetwork = 49,
     TWBlockchainSui = 50,
+    TWBlockchainInternetComputer = 53,
 };
 
 TW_EXTERN_C_END

--- a/include/TrustWalletCore/TWCoinType.h
+++ b/include/TrustWalletCore/TWCoinType.h
@@ -170,6 +170,7 @@ enum TWCoinType {
     TWCoinTypeAcalaEVM = 10000787,
     TWCoinTypeOpBNBtestnet = 5611,
     TWCoinTypeNeon = 245022934,
+    TWCoinTypeInternetComputer = 223,
 };
 
 /// Returns the blockchain for a coin type.

--- a/registry.json
+++ b/registry.json
@@ -4243,7 +4243,7 @@
     "blockchain": "InternetComputer",
     "derivation": [
       {
-        "path": "m/44'/223'/0'/0/0",
+        "path": "m/44'/223'/1'/0/0",
         "xpub": "xpub",
         "xpriv": "xpriv"
       }

--- a/registry.json
+++ b/registry.json
@@ -1613,7 +1613,6 @@
       "documentation": "https://developer.algorand.org/docs/algod-rest-paths"
     }
   },
-
   {
     "id": "iotex",
     "name": "IoTeX",
@@ -4233,6 +4232,36 @@
       "source": "https://github.com/neonevm/neon-evm",
       "rpc": "https://neon-proxy-mainnet.solana.p2p.org/",
       "documentation": "https://docs.neonfoundation.io/docs/quick_start"
+    }
+  },
+  {
+    "id": "icp",
+    "name": "Internet Computer",
+    "coinId": 223,
+    "symbol": "ICP",
+    "decimals": 8,
+    "blockchain": "InternetComputer",
+    "derivation": [
+      {
+        "path": "m/44'/223'/0'/0/0",
+        "xpub": "xpub",
+        "xpriv": "xpriv"
+      }
+    ],
+    "curve": "secp256k1",
+    "publicKeyType": "secp256k1",
+    "explorer": {
+      "url": "https://dashboard.internetcomputer.org/",
+      "txPath": "/transaction/",
+      "accountPath": "/account/",
+      "sampleTx": "9e32c54975adf84a1d98f19df41bbc34a752a899c32cc9c0000200b2c4308f85",
+      "sampleAccount": "529ea51c22e8d66e8302eabd9297b100fdb369109822248bb86939a671fbc55b"
+    },
+    "info": {
+      "url": "https://internetcomputer.org",
+      "source": "https://github.com/dfinity/ic",
+      "rpc": "",
+      "documentation": "https://internetcomputer.org/docs"
     }
   }
 ]

--- a/src/Coin.cpp
+++ b/src/Coin.cpp
@@ -64,6 +64,7 @@
 #include "Hedera/Entry.h"
 #include "TheOpenNetwork/Entry.h"
 #include "Sui/Entry.h"
+#include "InternetComputer/Entry.h" // TODO remove if the blockchain already exists, or just remove this comment if not
 // end_of_coin_includes_marker_do_not_modify
 
 using namespace TW;
@@ -119,6 +120,7 @@ Everscale::Entry EverscaleDP;
 Hedera::Entry HederaDP;
 TheOpenNetwork::Entry tonDP;
 Sui::Entry SuiDP;
+InternetComputer::Entry InternetComputerDP; // TODO remove if the blockchain already exists, or just remove this comment if not
 // end_of_coin_dipatcher_declarations_marker_do_not_modify
 
 CoinEntry* coinDispatcher(TWCoinType coinType) {
@@ -176,6 +178,7 @@ CoinEntry* coinDispatcher(TWCoinType coinType) {
         case TWBlockchainHedera: entry = &HederaDP; break;
         case TWBlockchainTheOpenNetwork: entry = &tonDP; break;
         case TWBlockchainSui: entry = &SuiDP; break;
+        case TWBlockchainInternetComputer: entry = &InternetComputerDP; break; // TODO remove if the blockchain already exists, or just remove this comment if not
         // end_of_coin_dipatcher_switch_marker_do_not_modify
 
         default: entry = nullptr; break;

--- a/src/InternetComputer/Address.cpp
+++ b/src/InternetComputer/Address.cpp
@@ -1,0 +1,33 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Address.h"
+
+namespace TW::InternetComputer {
+
+bool Address::isValid(const std::string& string) {
+    // TODO: Finalize implementation
+    return false;
+}
+
+Address::Address(const std::string& string) {
+    // TODO: Finalize implementation
+
+    if (!isValid(string)) {
+        throw std::invalid_argument("Invalid address string");
+    }
+}
+
+Address::Address(const PublicKey& publicKey) {
+    // TODO: Finalize implementation
+}
+
+std::string Address::string() const {
+    // TODO: Finalize implementation
+    return "TODO";
+}
+
+} // namespace TW::InternetComputer

--- a/src/InternetComputer/Address.h
+++ b/src/InternetComputer/Address.h
@@ -1,0 +1,38 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "Data.h"
+#include "PublicKey.h"
+
+#include <string>
+
+namespace TW::InternetComputer {
+
+class Address {
+  public:
+    // TODO: Complete class definition
+
+    /// Determines whether a string makes a valid address.
+    static bool isValid(const std::string& string);
+
+    /// Initializes a InternetComputer address with a string representation.
+    explicit Address(const std::string& string);
+
+    /// Initializes a InternetComputer address with a public key.
+    explicit Address(const PublicKey& publicKey);
+
+    /// Returns a string representation of the address.
+    std::string string() const;
+};
+
+inline bool operator==(const Address& lhs, const Address& rhs) {
+    // TODO: Complete equality operator
+    return true;
+}
+
+} // namespace TW::InternetComputer

--- a/src/InternetComputer/Entry.cpp
+++ b/src/InternetComputer/Entry.cpp
@@ -1,0 +1,31 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Entry.h"
+
+#include "Address.h"
+#include "Signer.h"
+
+namespace TW::InternetComputer {
+
+// Note: avoid business logic from here, rather just call into classes like Address, Signer, etc.
+
+bool Entry::validateAddress([[maybe_unused]] TWCoinType coin, const std::string& address, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
+    return Address::isValid(address);
+}
+
+std::string Entry::deriveAddress([[maybe_unused]] TWCoinType coin, const PublicKey& publicKey, [[maybe_unused]] TWDerivation derivation, [[maybe_unused]] const PrefixVariant& addressPrefix) const {
+    return Address(publicKey).string();
+}
+
+void Entry::sign(TWCoinType coin, const TW::Data& dataIn, TW::Data& dataOut) const {
+    signTemplate<Signer, Proto::SigningInput>(dataIn, dataOut);
+}
+
+void Entry::compile(TWCoinType coin, const Data& txInputData, const std::vector<Data>& signatures, const std::vector<PublicKey>& publicKeys, Data& dataOut) const {
+}
+
+} // namespace TW::InternetComputer

--- a/src/InternetComputer/Entry.h
+++ b/src/InternetComputer/Entry.h
@@ -1,0 +1,26 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "../CoinEntry.h"
+
+namespace TW::InternetComputer {
+
+/// Entry point for implementation of InternetComputer coin.
+/// Note: do not put the implementation here (no matter how simple), to avoid having coin-specific includes in this file
+class Entry final : public CoinEntry {
+public:
+    bool validateAddress(TWCoinType coin, const std::string& address, const PrefixVariant& addressPrefix) const;
+    std::string deriveAddress(TWCoinType coin, const PublicKey& publicKey, TWDerivation derivation, const PrefixVariant& addressPrefix) const;
+    void sign(TWCoinType coin, const Data& dataIn, Data& dataOut) const;
+    // normalizeAddress(): implement this if needed, e.g. Ethereum address is EIP55 checksummed
+    // plan(): implement this if the blockchain is UTXO based
+
+    void compile(TWCoinType coin, const Data& txInputData, const std::vector<Data>& signatures, const std::vector<PublicKey>& publicKeys, Data& dataOut) const;
+};
+
+} // namespace TW::InternetComputer

--- a/src/InternetComputer/Signer.cpp
+++ b/src/InternetComputer/Signer.cpp
@@ -1,0 +1,26 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "Signer.h"
+#include "Address.h"
+#include "../PublicKey.h"
+
+namespace TW::InternetComputer {
+
+Proto::SigningOutput Signer::sign(const Proto::SigningInput &input) noexcept {
+    // TODO: Check and finalize implementation
+
+    auto protoOutput = Proto::SigningOutput();
+    Data encoded;
+    // auto privateKey = PrivateKey(Data(input.private_key().begin(), input.private_key().end()));
+    // auto signature = privateKey.sign(payload, TWCurveED25519);
+    // encoded = encodeSignature(signature);
+
+    protoOutput.set_encoded(encoded.data(), encoded.size());
+    return protoOutput;
+}
+
+} // namespace TW::InternetComputer

--- a/src/InternetComputer/Signer.h
+++ b/src/InternetComputer/Signer.h
@@ -1,0 +1,25 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#pragma once
+
+#include "Data.h"
+#include "../PrivateKey.h"
+#include "../proto/InternetComputer.pb.h"
+
+namespace TW::InternetComputer {
+
+/// Helper class that performs InternetComputer transaction signing.
+class Signer {
+public:
+    /// Hide default constructor
+    Signer() = delete;
+
+    /// Signs a Proto::SigningInput transaction
+    static Proto::SigningOutput sign(const Proto::SigningInput& input) noexcept;
+};
+
+} // namespace TW::InternetComputer

--- a/src/proto/InternetComputer.proto
+++ b/src/proto/InternetComputer.proto
@@ -1,0 +1,32 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+syntax = "proto3";
+
+package TW.InternetComputer.Proto;
+option java_package = "wallet.core.jni.proto";
+
+// TODO: typical balance transfer, add more fields needed to sign
+message TransferMessage {
+    int64 amount = 1;
+    int64 fee = 2;
+    string to = 3;
+}
+
+// TODO: Input data necessary to create a signed transaction.
+message SigningInput {
+    bytes private_key = 1;
+
+    oneof message_oneof {
+        TransferMessage transfer = 2;
+    }
+}
+
+// Transaction signing output.
+message SigningOutput {
+    // Signed and encoded transaction bytes.
+    bytes encoded = 1;
+}

--- a/swift/Tests/Blockchains/InternetComputerTests.swift
+++ b/swift/Tests/Blockchains/InternetComputerTests.swift
@@ -1,0 +1,28 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+import WalletCore
+import XCTest
+
+class InternetComputerTests: XCTestCase {
+    // TODO: Check and finalize implementation
+
+    func testAddress() {
+        // TODO: Check and finalize implementation
+
+        let key = PrivateKey(data: Data(hexString: "__PRIVATE_KEY_DATA__")!)!
+        let pubkey = key.getPublicKeyEd25519()
+        let address = AnyAddress(publicKey: pubkey, coin: .internetcomputer)
+        let addressFromString = AnyAddress(string: "__ADDRESS_DATA__", coin: .internetcomputer)!
+
+        XCTAssertEqual(pubkey.data.hexString, "__EXPECTED_PUBKEY_DATA__")
+        XCTAssertEqual(address.description, addressFromString.description)
+    }
+
+    func testSign() {
+        // TODO: Create implementation
+    }
+}

--- a/tests/chains/InternetComputer/AddressTests.cpp
+++ b/tests/chains/InternetComputer/AddressTests.cpp
@@ -1,0 +1,49 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "HexCoding.h"
+#include "InternetComputer/Address.h"
+#include "PublicKey.h"
+#include "PrivateKey.h"
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace TW::InternetComputer::tests {
+
+TEST(InternetComputerAddress, Valid) {
+    ASSERT_TRUE(Address::isValid("__ADD_VALID_ADDRESS_HERE__"));
+
+    // TODO: Add more tests
+}
+
+TEST(InternetComputerAddress, Invalid) {
+    ASSERT_FALSE(Address::isValid("__ADD_INVALID_ADDRESS_HERE__"));
+
+    // TODO: Add more tests
+}
+
+TEST(InternetComputerAddress, FromPrivateKey) {
+    // TODO: Check public key type, finalize implementation
+
+    auto privateKey = PrivateKey(parse_hex("__PRIVATE_KEY_DATA__"));
+    auto address = Address(privateKey.getPublicKey(TWPublicKeyTypeED25519));
+    ASSERT_EQ(address.string(), "__ADD_RESULTING_ADDRESS_HERE__");
+}
+
+TEST(InternetComputerAddress, FromPublicKey) {
+    // TODO: Check public key type, finalize implementation
+    
+    auto publicKey = PublicKey(parse_hex("__PUBLIC_KEY_DATA__"), TWPublicKeyTypeED25519);
+    auto address = Address(publicKey);
+    ASSERT_EQ(address.string(), "__ADD_RESULTING_ADDRESS_HERE__");
+}
+
+TEST(InternetComputerAddress, FromString) {
+    auto address = Address("__ADD_VALID_ADDRESS_HERE__");
+    ASSERT_EQ(address.string(), "__ADD_SAME_VALID_ADDRESS_HERE__");
+}
+
+} // namespace TW::InternetComputer::tests

--- a/tests/chains/InternetComputer/SignerTests.cpp
+++ b/tests/chains/InternetComputer/SignerTests.cpp
@@ -1,0 +1,35 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "InternetComputer/Signer.h"
+#include "InternetComputer/Address.h"
+#include "HexCoding.h"
+#include "PrivateKey.h"
+#include "PublicKey.h"
+
+#include <gtest/gtest.h>
+
+namespace TW::InternetComputer::tests {
+
+// TODO: Add tests
+
+TEST(InternetComputerSigner, Sign) {
+    // TODO: Finalize test implementation
+
+    //auto key = PrivateKey(parse_hex("__PRIVKEY_DATA__"));
+    //auto publicKey = key.getPublicKey(TWPublicKeyTypeED25519);
+    //auto from = Address(publicKey);
+    //auto to = Address("__TO_ADDRESS__");
+    //...
+    //auto transaction = Transaction(...)
+    //auto signature = Signer::sign(key, transaction);
+    //auto result = transaction.serialize(signature);
+
+    //ASSERT_EQ(hex(serialized), "__RESULT__");
+    //ASSERT_EQ(...)
+}
+
+} // namespace TW::InternetComputer::tests

--- a/tests/chains/InternetComputer/TWAnyAddressTests.cpp
+++ b/tests/chains/InternetComputer/TWAnyAddressTests.cpp
@@ -1,0 +1,26 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include <TrustWalletCore/TWAnyAddress.h>
+#include "HexCoding.h"
+
+#include "TestUtilities.h"
+#include <gtest/gtest.h>
+
+using namespace TW;
+
+// TODO: Finalize tests
+
+TEST(TWInternetComputer, Address) {
+    // TODO: Finalize test implementation
+
+    auto string = STRING("__ADD_VALID_ADDRESS_HERE__");
+    auto addr = WRAP(TWAnyAddress, TWAnyAddressCreateWithString(string.get(), TWCoinTypeInternetComputer));
+    auto string2 = WRAPS(TWAnyAddressDescription(addr.get()));
+    EXPECT_TRUE(TWStringEqual(string.get(), string2.get()));
+    auto keyHash = WRAPD(TWAnyAddressData(addr.get()));
+    assertHexEqual(keyHash, "__CORRESPONDING_ADDRESS_DATA__");
+}

--- a/tests/chains/InternetComputer/TWAnySignerTests.cpp
+++ b/tests/chains/InternetComputer/TWAnySignerTests.cpp
@@ -1,0 +1,19 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include <TrustWalletCore/TWAnySigner.h>
+#include "HexCoding.h"
+
+#include "TestUtilities.h"
+#include <gtest/gtest.h>
+
+using namespace TW;
+
+// TODO: Finalize tests
+
+TEST(TWAnySignerInternetComputer, Sign) {
+    // TODO: Finalize test implementation
+}

--- a/tests/chains/InternetComputer/TWCoinTypeTests.cpp
+++ b/tests/chains/InternetComputer/TWCoinTypeTests.cpp
@@ -1,0 +1,35 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+//
+// This is a GENERATED FILE, changes made here MAY BE LOST.
+// Generated one-time (codegen/bin/cointests)
+//
+
+#include "TestUtilities.h"
+#include <TrustWalletCore/TWCoinTypeConfiguration.h>
+#include <gtest/gtest.h>
+
+
+TEST(TWInternetComputerCoinType, TWCoinType) {
+    const auto coin = TWCoinTypeInternetComputer;
+    const auto symbol = WRAPS(TWCoinTypeConfigurationGetSymbol(coin));
+    const auto id = WRAPS(TWCoinTypeConfigurationGetID(coin));
+    const auto name = WRAPS(TWCoinTypeConfigurationGetName(coin));
+    const auto txId = WRAPS(TWStringCreateWithUTF8Bytes("9e32c54975adf84a1d98f19df41bbc34a752a899c32cc9c0000200b2c4308f85"));
+    const auto txUrl = WRAPS(TWCoinTypeConfigurationGetTransactionURL(coin, txId.get()));
+    const auto accId = WRAPS(TWStringCreateWithUTF8Bytes("529ea51c22e8d66e8302eabd9297b100fdb369109822248bb86939a671fbc55b"));
+    const auto accUrl = WRAPS(TWCoinTypeConfigurationGetAccountURL(coin, accId.get()));
+
+    assertStringsEqual(id, "icp");
+    assertStringsEqual(name, "InternetComputer");
+    assertStringsEqual(symbol, "ICP");
+    ASSERT_EQ(TWCoinTypeConfigurationGetDecimals(coin), 8);
+    ASSERT_EQ(TWCoinTypeBlockchain(coin), TWBlockchainInternetComputer);
+    ASSERT_EQ(TWCoinTypeP2shPrefix(coin), 0x0);
+    ASSERT_EQ(TWCoinTypeStaticPrefix(coin), 0x0);
+    assertStringsEqual(txUrl, "https://dashboard.internetcomputer.org//transaction/9e32c54975adf84a1d98f19df41bbc34a752a899c32cc9c0000200b2c4308f85");
+    assertStringsEqual(accUrl, "https://dashboard.internetcomputer.org//account/529ea51c22e8d66e8302eabd9297b100fdb369109822248bb86939a671fbc55b");
+}

--- a/tests/chains/InternetComputer/TransactionCompilerTests.cpp
+++ b/tests/chains/InternetComputer/TransactionCompilerTests.cpp
@@ -1,0 +1,30 @@
+// Copyright © 2017-2023 Trust Wallet.
+//
+// This file is part of Trust. The full Trust copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+#include "InternetComputer/Signer.h"
+#include "InternetComputer/Address.h"
+#include "HexCoding.h"
+#include "PrivateKey.h"
+#include "PublicKey.h"
+#include "TestUtilities.h"
+#include "TransactionCompiler.h"
+
+#include "proto/InternetComputer.pb.h"
+#include "proto/TransactionCompiler.pb.h"
+
+#include <TrustWalletCore/TWCoinType.h>
+
+#include <gtest/gtest.h>
+
+using namespace TW;
+
+namespace TW::InternetComputer {
+
+TEST(InternetComputerCompiler, CompileWithSignatures) {
+    // TODO: Finalize test implementation
+}
+
+} // namespace TW::InternetComputer


### PR DESCRIPTION
This PR kickoffs the project by adding the skeleton to start working on the integration. The steps taken:

0. Ran the `./bootstrap.sh` script.
1. Installed emscripten `sudo apt-get install -y emscripten` into the devcontainer.
2. Added ICP to the `registry.json`.
3. Ran `./codegen/bin/newcoin icp` which generates the protobuf definitions and the code needed to start.
4. Ran `./tools/generate-files` to generate the protobuf classes.